### PR TITLE
add filter for query params

### DIFF
--- a/class-wp-twitter-api.php
+++ b/class-wp-twitter-api.php
@@ -137,6 +137,7 @@ class WP_Twitter_API {
 	 */
 	public function get( $url, $params = array(), $defaults = array() ) {
 		$params = wp_parse_args( $params, $defaults );
+		$params = apply_filters( 'wp_twitter_api_query_params', $params, $url );
 		$cache_key = 'tafwp_' . md5( $url . serialize( $params ) );
 		if ( false === ( $response = get_transient( $cache_key ) ) ) {
 			$this->connect();

--- a/class-wp-twitter-api.php
+++ b/class-wp-twitter-api.php
@@ -137,6 +137,13 @@ class WP_Twitter_API {
 	 */
 	public function get( $url, $params = array(), $defaults = array() ) {
 		$params = wp_parse_args( $params, $defaults );
+		/**
+		 * Filter Twitter GET Params.
+		 *
+		 * Filters the params for the twitter endpoint.
+		 * @param array $params GET params to send.
+		 * @param string $url The API endpoint, e.g. statuses/user_timeline.
+		 */
 		$params = apply_filters( 'wp_twitter_api_query_params', $params, $url );
 		$cache_key = 'tafwp_' . md5( $url . serialize( $params ) );
 		if ( false === ( $response = get_transient( $cache_key ) ) ) {


### PR DESCRIPTION
This allows the theme to override the parameters.  Let me know if you want to see an example of how I'm using this.  My use case is to use it to exclude replies for user timeline queries.  Here's some helpful documentation: https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-user_timeline.html