### PR TITLE
Extends 1.1 Functionality

### DIFF
--- a/class-wp-twitter-api.php
+++ b/class-wp-twitter-api.php
@@ -164,7 +164,8 @@ class WP_Twitter_API {
 	public function get_user_timeline( $params = array() ) {
 		return $this->get( 'statuses/user_timeline', $params, array(
 			'count'       => 20,
-			'include_rts' => 1
+			'include_rts' => 1,
+			'tweet_mode'  => 'extended',
 		) );
 	}
 
@@ -178,7 +179,7 @@ class WP_Twitter_API {
 	public function get_list_timeline( $params = array() ) {
 		return $this->get( 'lists/statuses', $params, array(
 			'count'       => 20,
-			'include_rts' => 1
+			'include_rts' => 1,
 		) );
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -124,7 +124,7 @@ function tapi_get_author_avatar_url( $protocol = 'http', $tweet = false ) {
 
 
 function tapi_get_author_permalink( $tweet = false ) {
-	return "https://twitter.com/" . tapi_get_author_screen_name();
+	return "https://twitter.com/" . tapi_get_author_screen_name( $tweet );
 }
 
 

--- a/functions.php
+++ b/functions.php
@@ -132,7 +132,22 @@ function tapi_get_text( $tweet = false ) {
 	if ( ! $tweet )
 		$tweet = $GLOBALS['tapi_tweet'];
 
-	return $tweet->full_text;
+	if ( ! empty( $tweet->full_text ) ) {
+		preg_match_all('/https:\/\/t.co\/[^\s]+/', $tweet->full_text, $matches );
+
+		if ( ! empty( $matches[0] ) ) {
+			$new_string = $tweet->full_text;
+
+			// Loop through an replace matches.
+			foreach ( $matches[0] as $match ) {
+				$new_string = str_replace( $match, wp_kses_post( '<a href="' . $match . '" rel=”nofollow”>' . $match . '</a>' ),  $new_string );
+			}
+
+			return nl2br( $new_string );
+		}
+	}
+
+	return nl2br( $tweet->full_text );
 }
 
 
@@ -217,3 +232,29 @@ function tapi_get_relative_time( $timestamp = '' ) {
 	return $time_string;
 }
 
+/**
+ * Get media for tweet.
+ *
+ * @param object $tweet tweet object.
+ * @return array array of media if it exists.
+ */
+function tapi_get_media_url( $tweet = false ) {
+	if ( ! $tweet )
+		$tweet = $GLOBALS['tapi_tweet'];
+
+	// Set empty array.
+	$media_array = [];
+
+	if ( isset( $tweet->entities ) && isset( $tweet->entities->media ) ) {
+
+		foreach ( $tweet->entities->media as $media ) {
+			$media_array[] = $media->media_url_https
+				? $media->media_url_https
+				: $media->media_url;
+
+			return $media_array;
+		}
+	}
+
+	return $media_array;
+}

--- a/functions.php
+++ b/functions.php
@@ -128,11 +128,11 @@ function tapi_get_author_permalink( $tweet = false ) {
 }
 
 
-function tapi_get_text( $state = 'filtered', $tweet = false ) {
+function tapi_get_text( $tweet = false ) {
 	if ( ! $tweet )
 		$tweet = $GLOBALS['tapi_tweet'];
 
-	return $tweet->text( $state );
+	return $tweet->full_text;
 }
 
 

--- a/twitter_oauth/twitteroauth.php
+++ b/twitter_oauth/twitteroauth.php
@@ -20,7 +20,7 @@ class TwitterOAuth {
 	public $url;
 
 	/* Set up the API root URL. */
-	public $host = "https://api.twitter.com/1/";
+	public $host = "https://api.twitter.com/1.1/";
 
 	/* Set timeout default. */
 	public $timeout = 30;


### PR DESCRIPTION
- adds “tweet_mode” param to user_timeline fetch to get longer-than-140-character tweets
Re: https://developer.twitter.com/en/docs/tweets/tweet-updates

- adds missing param in author permalink function
- Replaces defunct `$tweet->age( $tweet )` with `tapi_get_relative_time function`
- replaces `tapi_get_text` call with direct object call
- replaces `full_text` links with live links
- updates host from 1 to 1.1